### PR TITLE
ci: drop EOL Emacs 25.x and 26.x from test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,12 +10,6 @@ jobs:
       fail-fast: false
       matrix:
         emacs_version:
-          - '25.1'
-          - '25.2'
-          - '25.3'
-          - '26.1'
-          - '26.2'
-          - '26.3'
           - '27.1'
           - 'snapshot'
         include:

--- a/README.org
+++ b/README.org
@@ -84,7 +84,7 @@ Exit codes:
 
 * Requirements
 
-- Emacs 25.1 or later
+- Emacs 27.1 or later
 - [[https://github.com/chuntaro/emacs-async-await][async-await]]
 - [[https://github.com/jwiegley/emacs-async][async]]
 - [[https://github.com/chuntaro/emacs-promise][promise]]

--- a/flycheck-indent.el
+++ b/flycheck-indent.el
@@ -5,7 +5,7 @@
 ;; Author: Naoya Yamashita <conao3@gmail.com>
 ;; Version: 1.0.0
 ;; Keywords: tools
-;; Package-Requires: ((emacs "25.1") (indent-lint "1.0.0") (flycheck "31"))
+;; Package-Requires: ((emacs "27.1") (indent-lint "1.0.0") (flycheck "31"))
 ;; URL: https://github.com/conao3/indent-lint.el
 
 ;; This program is free software: you can redistribute it and/or modify

--- a/indent-lint.el
+++ b/indent-lint.el
@@ -5,7 +5,7 @@
 ;; Author: Naoya Yamashita <conao3@gmail.com>
 ;; Version: 1.1.4
 ;; Keywords: tools
-;; Package-Requires: ((emacs "25.1") (async-await "1.0") (async "1.9.4") (promise "1.1"))
+;; Package-Requires: ((emacs "27.1") (async-await "1.0") (async "1.9.4") (promise "1.1"))
 ;; URL: https://github.com/conao3/indent-lint.el
 
 ;; This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
## Root cause

The latest `Main workflow` run on `master` ([commit dca07b7](https://github.com/conao3/indent-lint.el/commit/dca07b7bf5f59015ffaa6ffea3d7129b81485ec4), run #58) failed. The job/step breakdown shows pure EOL-Emacs matrix rot:

| Emacs | Result | Failing step |
|-------|--------|--------------|
| 25.1  | fail   | `purcell/setup-emacs` (can no longer provision this binary) |
| 25.2  | fail   | `make test` |
| 25.3  | fail   | `make test` |
| 26.1  | fail   | `purcell/setup-emacs` (can no longer provision this binary) |
| 26.2  | fail   | `make test` |
| 26.3  | fail   | `make test` |
| 27.1  | pass   | — |
| snapshot | pass | — (allow_failure) |

- Emacs 25.1 / 26.1 are no longer available from `purcell/setup-emacs`, so the setup step itself fails — unfixable from our side.
- 25.2 / 25.3 / 26.2 / 26.3 install fine but `make test` fails: `cask install` now resolves a modern `flycheck`, whose current releases require Emacs ≥ 27.1, so byte-compilation / buttercup fails on these old Emacsen.

Only 27.1 and snapshot remain viable. This is matrix rot, not a code/test bug (identical code passes on 27.1 and snapshot).

## Fix

- Remove the failing EOL versions (25.1, 25.2, 25.3, 26.1, 26.2, 26.3) from the matrix; keep 27.1 and snapshot.
- Bump the `Package-Requires` Emacs floor `25.1 → 27.1` in `indent-lint.el` and `flycheck-indent.el` to stay consistent with the lowest supported/tested version.
- Update the README requirement line to match.

## Test plan

- [ ] CI green on Emacs 27.1
- [ ] snapshot job runs (allow_failure)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CQ87Bi2BKXumpUbSNP1rsw)_