### PR TITLE
chore: update dependencies to latest versions

### DIFF
--- a/flycheck-indent.el
+++ b/flycheck-indent.el
@@ -5,7 +5,7 @@
 ;; Author: Naoya Yamashita <conao3@gmail.com>
 ;; Version: 1.0.0
 ;; Keywords: tools
-;; Package-Requires: ((emacs "27.1") (indent-lint "1.0.0") (flycheck "31"))
+;; Package-Requires: ((emacs "27.1") (indent-lint "1.1.4") (flycheck "36"))
 ;; URL: https://github.com/conao3/indent-lint.el
 
 ;; This program is free software: you can redistribute it and/or modify

--- a/indent-lint.el
+++ b/indent-lint.el
@@ -5,7 +5,7 @@
 ;; Author: Naoya Yamashita <conao3@gmail.com>
 ;; Version: 1.1.4
 ;; Keywords: tools
-;; Package-Requires: ((emacs "27.1") (async-await "1.0") (async "1.9.4") (promise "1.1"))
+;; Package-Requires: ((emacs "27.1") (async-await "1.1") (async "1.9.7") (promise "1.1"))
 ;; URL: https://github.com/conao3/indent-lint.el
 
 ;; This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
## Summary

Modernizes the package dependency constraints to their latest compatible versions.

| Dependency | Before | After |
|---|---|---|
| `async-await` | 1.0 | 1.1 |
| `async` | 1.9.4 | 1.9.7 |
| `promise` | 1.1 | 1.1 (already latest) |
| `flycheck` | 31 | 36 |
| `indent-lint` (req in flycheck-indent) | 1.0.0 | 1.1.4 |

`emacs` requirement kept at 27.1 — Flycheck 36 still supports Emacs 27, and the CI matrix exercises 27.1.

No lockfile exists for this Cask-based project, so there is nothing to regenerate. No major upgrades were deferred — all bumps build and test green.

## Test plan

- [x] `make test` (byte-compile + buttercup) passes on Emacs 29.3 with the bumped constraints; Cask resolves `async 1.9.7` / `async-await 1.1` / `flycheck` latest (36) / `promise 1.1`.
- [ ] CI (`Main workflow`) green on Emacs 27.1 and snapshot.

https://claude.ai/code/session_014qktbAnq9hNbu2rgKye43Z

---
_Generated by [Claude Code](https://claude.ai/code/session_014qktbAnq9hNbu2rgKye43Z)_